### PR TITLE
Feature/Ajout d'un lien vers l'achat de billet pour la roboCup

### DIFF
--- a/en.clubnaova.ca/index.html
+++ b/en.clubnaova.ca/index.html
@@ -120,6 +120,10 @@
 					<p>Every team are composed of the same standard robots, there has to be a difference in the program dictating its comportment.</p><br>
 
           <p>Come to encourage us from June 15 to 22, 2018 at the Palais des Congrès in Montreal to attend our first participation in the RoboCup!</p>
+
+          <center><a href="https://secure.ticketpro.ca/?lang=en&server=ww1&aff=RoboCup#def_1288916787" class="btn btn-default">Buy tickets!</a></center><br>
+
+          <p>* For the ETS's student it's FREE entry!</p>
 				</h3>
 				<br>
           </div>
@@ -437,6 +441,11 @@
       <a href="http://www.robocup.org/" style="text-decoration: underline;color: #0800f9;">Learn more about RoboCup</a>
       </br>
       <a href="http://www.robocup2018.org" style="text-decoration: underline;color: #0800f9;">Learn more about RoboCup Montréal 2018</a>
+      <br>
+      <br>
+      <a href="https://secure.ticketpro.ca/?lang=en&server=ww1&aff=RoboCup#def_1288916787" class="btn btn-primary">Buy tickets!</a><br>
+
+      <p>* For the ETS's student it's FREE entry!</p>
       </center>
     </br>
     </div>

--- a/fr.clubnaova.ca/index.html
+++ b/fr.clubnaova.ca/index.html
@@ -122,6 +122,9 @@
 
           <p>Venez nous encourager du 15 au 22 juin 2018 au Palais des Congrès de Montréal pour assister à notre première participation à la RoboCup!</p>
 
+          <center><a href="https://secure.ticketpro.ca/?server=ww1&aff=RoboCup&lang=fr#def_1288916787" class="btn btn-default">Achat de billets!</a></center><br>
+
+          <p>* Pour les étudiants de l'ETS l'entrée est GRATUITE!</p>
 				</h3>
 				<br>
           </div>
@@ -443,6 +446,11 @@
       <a href="http://www.robocup.org/" style="text-decoration: underline;color: #0800f9;">Plus d'information sur la RoboCup</a>
       </br>
       <a href="http://www.robocup2018.org" style="text-decoration: underline;color: #0800f9;">Plus d'information sur la RoboCup Montréal 2018</a>
+      </br>
+      </br>
+      <a href="https://secure.ticketpro.ca/?server=ww1&aff=RoboCup&lang=fr#def_1288916787" class="btn btn-primary">Achat de billets!</a>
+
+      <p>* Pour les étudiants de l'ETS l'entrée est GRATUITE!</p>
       </center>
     </br>
     </div>


### PR DESCRIPTION
À la demande de Jo : Ajout d'un button vers la page de la roboCup pour acheter des billets + ajout de l'information que pour un etudiant de l'ETS l'entrée est gratuite